### PR TITLE
Set debug configuration properties to default values

### DIFF
--- a/src/OP2Script.vcxproj
+++ b/src/OP2Script.vcxproj
@@ -53,7 +53,7 @@
     <PostBuildEventUseInBuild Condition="'$(Configuration)|$(Platform)'=='Release MinSize|Win32'">false</PostBuildEventUseInBuild>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Configuration)\</IntDir>
-    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
     <PostBuildEventUseInBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</PostBuildEventUseInBuild>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -143,7 +143,7 @@ copy NetHelper.pdb ..\Outpost2\NetHelper</Command>
       <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <ForcedIncludeFiles>%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <ResourceCompile>


### PR DESCRIPTION
miniupnp and libnatpmp MSVC project settings allow for incremental debug builds and edit and continue compilation. This causes a warning when compiling NetHelper in debug mode. Since incremental debug builds were disabled in NetHelper, MSVC was having to set both miniupnp and libnatpmp projects to disable incremental debug builds which was contrary to their settings.

https://docs.microsoft.com/en-us/cpp/build/reference/incremental-link-incrementally?view=vs-2017

Adding incremental debug builds means that some extra padding and 'jump thunks' (don't know what they are?) may be included in the compilation. We should watch and make sure this does not cause problems with how NetHelper hooks to Outpost 2. If problems are caused, we can disable it and go against the default setting. Incremental building is disabled in Release mode, so not a concern on final DLL.