### PR TITLE
Set Safe Exception Handling to FALSE on DEBUG builds

### DIFF
--- a/src/OP2Script.vcxproj
+++ b/src/OP2Script.vcxproj
@@ -166,6 +166,7 @@ copy NetHelper.pdb ..\Outpost2\NetHelper</Command>
       </DataExecutionPrevention>
       <ImportLibrary>.\Debug/NetHelper.lib</ImportLibrary>
       <TargetMachine>MachineX86</TargetMachine>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <Bscmake>
       <SuppressStartupBanner>true</SuppressStartupBanner>


### PR DESCRIPTION
Safe Exception Handling prevents Edit and Continue compiling on Debug builds and is recommended to disable on debug builds. Will still be enabled on release builds.https://social.msdn.microsoft.com/Forums/vstudio/en-US/30a23b09-190d-44e9-9157-4b896cc11e73/safeseh-disables-edit-and-continue?forum=vcgeneral

Warning	LNK4075	ignoring '/EDITANDCONTINUE' due to '/SAFESEH' specification	NetHelper	\NetHelper\src\Main.obj	1