### PR TITLE
Replace numeric constant with INET6_ADDRSTRLEN

### DIFF
--- a/src/PortForward.cpp
+++ b/src/PortForward.cpp
@@ -5,7 +5,6 @@
 
 #include <windows.h>
 #include <stdio.h>
-#include <ws2tcpip.h>
 #include <winsock2.h>
 #include <iphlpapi.h>
 #include <memory>

--- a/src/PortForward.cpp
+++ b/src/PortForward.cpp
@@ -20,8 +20,8 @@ static bool GetInterfaceToInternet(in_addr_t *outGateway);
 static int ListenForPmpResponse(natpmp_t &natPmp, natpmpresp_t *response = nullptr,
                                 int maxTries = 9);
 
-char PortForwarder::internalIp[46] = {},
-     PortForwarder::externalIp[46] = {};
+char PortForwarder::internalIp[INET6_ADDRSTRLEN] = {},
+     PortForwarder::externalIp[INET6_ADDRSTRLEN] = {};
 
 
 PortForwarder::PortForwarder() {

--- a/src/PortForward.h
+++ b/src/PortForward.h
@@ -21,8 +21,8 @@ public:
   bool IsUsingUpnp();
   bool IsUsingPmp();
 
-  static char internalIp[46],
-              externalIp[46];
+  static char internalIp[INET6_ADDRSTRLEN],
+              externalIp[INET6_ADDRSTRLEN];
 
 private:
   bool upnpInited,

--- a/src/PortForward.h
+++ b/src/PortForward.h
@@ -3,6 +3,7 @@
 #ifndef PORTFORWARD_H
 #define PORTFORWARD_H
 
+#include <ws2tcpip.h>
 #include "../miniupnp/miniupnpc/miniupnpc.h"
 #include "../libnatpmp/natpmp.h"
 


### PR DESCRIPTION
Split from the previous branch in PR #11. We may need to add appropriate header includes for the `INET6_ADDRSTRLEN` constant. The includes might be platform specific.

Suggested header from the other branch:
```cpp
#include <ws2tcpip.h>
```
